### PR TITLE
Add additional Elon reply responses

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -535,6 +535,8 @@ elon_responses = [
     "Such ingratitude",
     "Wise words",
     "I miss Chris",
+    "{user} probably got flack from his wife's bf for posting this and had to write up a grovelling apology",
+    "I'm not upset, just remarking that this sounds fake and gay",
     "{user} is a liar and delights in being mean. Not a good human"
 ]
 


### PR DESCRIPTION
### Motivation
- Expand the variety of replies returned by the `Elon Reply` message command to provide more conversational and user-interpolated responses.

### Description
- Added two new entries to the `elon_responses` list in `cogs/fun.py`, including one response that uses `{user}` interpolation to match existing behavior.

### Testing
- No automated tests were run; this is a static response-pool update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109c32da4483209b850f9fec37a306)