### PR TITLE
Update xQc profile picture

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -984,7 +984,7 @@ async def xqc_explains(interaction: discord.Interaction, message: discord.Messag
         
         embed.set_author(
             name="xQc", 
-            icon_url="https://pbs.twimg.com/profile_images/1702011519049904128/JXVYGukS_400x400.jpg"
+            icon_url="https://pbs.twimg.com/profile_images/1948335986007474176/diqK-2Jj_400x400.jpg"
         )
         
         await message.reply(embed=embed)


### PR DESCRIPTION
### Motivation
- Replace the embed author icon used by the "xQc Explains" command with the requested current profile image.

### Description
- Update `cogs/fun.py` to change the `embed.set_author(..., icon_url=...)` value to `https://pbs.twimg.com/profile_images/1948335986007474176/diqK-2Jj_400x400.jpg`.

### Testing
- Ran `git diff --check`, `python -m compileall -q cogs/fun.py`, and `git status --short`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e77e7fee08320a83c582f951ef882)